### PR TITLE
feat: add reusable workflow for publishing kustomize manifests

### DIFF
--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -1,0 +1,59 @@
+name: Publish Kustomize Bundle
+
+on:
+  workflow_call:
+    inputs:
+      bundle-name:
+        required: true
+        type: string
+        description: "The full name of the bundle that should be used, including the repository (e.g. `ghcr.io/datum-cloud/telemetry-services-operator/crds`)"
+      bundle-path:
+        required: true
+        type: string
+        description: "The path to the bundle that should be used, relative to the root of the repository (e.g. `config/crds`)"
+
+jobs:
+  publish-kustomize-bundle:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: azure/setup-kubectl@v4
+      - name: Build Kustomize Bundle
+        run: |
+          kubectl kustomize ${{ inputs.bundle-path }} > bundle.yaml
+      - name: Setup Flux CLI
+        uses: fluxcd/flux2/action@main
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ inputs.bundle-name }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Publish Bundle
+        run: |
+          echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
+            flux push artifact \
+              oci://${tag} \
+              --path bundle.yaml \
+              --source https://github.com/${{ github.repository }} \
+              --revision $(echo "$tag" | cut -d':' -f2)@sha1:$(git rev-parse HEAD)
+          done

--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -50,10 +50,11 @@ jobs:
             type=sha
       - name: Publish Bundle
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
+          while IFS= read -r tag; do
+            tag_version="${tag#*:}"
             flux push artifact \
-              oci://${tag} \
-              --path bundle.yaml \
-              --source https://github.com/${{ github.repository }} \
-              --revision $(echo "$tag" | cut -d':' -f2)@sha1:$(git rev-parse HEAD)
-          done
+              "oci://${tag}" \
+              --path="bundle.yaml" \
+              --source="https://github.com/${GITHUB_REPOSITORY}" \
+              --revision="${tag_version}@sha1:$(git rev-parse HEAD)"
+          done < <(echo "${{ steps.meta.outputs.tags }}")

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@ available.
 ## Actions
 
 - [Publish Docker Images to Artifact Registry](./publish-docker/)
+- [Publish Kustomize Bundle to GHCR](./publish-kustomize-bundle/)

--- a/docs/publish-kustomize-bundle/README.md
+++ b/docs/publish-kustomize-bundle/README.md
@@ -1,0 +1,50 @@
+# Publish Kustomize Bundle
+
+The `.github/workflows/publish-kustomize-bundle.yaml` reusable GitHub Action
+builds and pushes a Kustomize bundle to **GitHub Container Registry**.
+
+## 🚀 Usage
+
+## Inputs
+
+- **bundle-name**: The full name of the bundle that should be used, including
+  the repository (e.g. `ghcr.io/datum-cloud/telemetry-services-operator/crds`).
+- **bundle-path**: The path to the bundle that should be used, relative to the
+  root of the repository (e.g. `config/crds`).
+
+## Best Practices
+
+- Always use a tagged version when referencing the GitHub action workflow to
+  prevent unexpected breaking changes.
+
+> [!IMPORTANT]
+>
+> Add the following to your `.gitignore` and `.dockerignore` files to exclude
+> the automatically generated credentials from ever being included in the
+> resulting docker container or committed to the repo.
+>
+> ```
+> # Ignore generated credentials from google-github-actions/auth
+> gha-creds-*.json
+> ```
+
+### **Workflow Example**
+
+Create a workflow in your repository (e.g., `.github/workflows/publish.yaml`)
+that calls this reusable action:
+
+```yaml
+name: Publish Kustomize Bundle
+
+on:
+  push:
+  release:
+    types: ['published']
+
+jobs:
+  publish:
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1
+    with:
+      bundle-name: ghcr.io/datum-cloud/telemetry-services-operator/crds
+      bundle-path: config/crds
+```


### PR DESCRIPTION
This PR introduces a new GitHub Action that can be used to build kustomization manifests from a repository and publish them as an OCI repository image that can be used by Flux.