### PR TITLE
Publish kustomize bundle as a directory

### DIFF
--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -28,10 +28,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: azure/setup-kubectl@v4
-      - name: Build Kustomize Bundle
-        run: |
-          kubectl kustomize ${{ inputs.bundle-path }} > bundle.yaml
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
       - name: Extract metadata
@@ -54,7 +50,7 @@ jobs:
             tag_version="${tag#*:}"
             flux push artifact \
               "oci://${tag}" \
-              --path="bundle.yaml" \
+              --path="${{ inputs.bundle-path }}" \
               --source="https://github.com/${GITHUB_REPOSITORY}" \
               --revision="${tag_version}@sha1:$(git rev-parse HEAD)"
           done < <(echo "${{ steps.meta.outputs.tags }}")


### PR DESCRIPTION
This change allows the workflow to publish a kustomize bundle as a directory to the OCI registry giving the user the ability to specify which kustomize bundle they want to use when deploying via Flux.