### PR TITLE
chore: align tagging conventions

### DIFF
--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -40,9 +40,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=sha
       - name: Publish Bundle
         run: |


### PR DESCRIPTION
This aligns the tagging conventions we use for publishing docker containers. 