### PR TITLE
Publish Docker Images to GitHub

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -18,24 +18,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v2'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
         with:
-          project_id: ${{ vars.GCP_ARTIFACT_REPOSITORY_PROJECT }}
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
-
-      - name: Configure Docker to use Artifact Registry
-        run: |
-          gcloud auth configure-docker ${{ vars.GCP_ARTIFACT_REGISTRY_LOCATION }}-docker.pkg.dev
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.GCP_ARTIFACT_REGISTRY }}/${{ inputs.image-name }}
+          images: ghcr.io/datum-cloud/${{ inputs.image-name }}
           tags: |
             type=ref,event=pr
             type=ref,event=branch

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3

--- a/docs/publish-docker/README.md
+++ b/docs/publish-docker/README.md
@@ -1,13 +1,11 @@
 # Publish Docker Images
 
 The `.github/workflows/publish-docker.yaml` reusable GitHub Action builds and
-pushes a Docker image to **Google Cloud Artifact Registry** using **Workload
-Identity Federation** for authentication. It eliminates the need for long-lived
-credentials, improving security and maintainability.
+pushes a Docker image to **GitHub Container Registry**.
 
 ## 🚀 Usage
 
-## Inputs
+### Inputs
 
 - **image-name**: The name of the docker image (without the registry) that
   should be used (e.g. cloud-portal).
@@ -16,18 +14,6 @@ credentials, improving security and maintainability.
 
 - Always use a tagged version when referencing the GitHub action workflow to
   prevent unexpected breaking changes.
-
-
-> [!IMPORTANT]
->
-> Add the following to your `.gitignore` and `.dockerignore` files to exclude
-> the automatically generated credentials from ever being included in the
-> resulting docker container or committed to the repo.
->
-> ```
-> # Ignore generated credentials from google-github-actions/auth
-> gha-creds-*.json
-> ```
 
 ### **Workflow Example**
 


### PR DESCRIPTION
Updates the Publish Docker GitHub Action workflow to publish docker images to the GitHub container registry. Consolidating images onto GitHub actions as packages so they're more accessible to the community.