### PR TITLE
feat: add PR timestamp tag

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -34,6 +34,7 @@ jobs:
           images: ghcr.io/datum-cloud/${{ inputs.image-name }}
           tags: |
             type=ref,event=pr
+            type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
             type=ref,event=branch
             type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
             type=semver,pattern=v{{version}}

--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -50,14 +50,15 @@ jobs:
         with:
           images: ${{ inputs.bundle-name }}
           tags: |
-            type=schedule
-            type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
+            type=ref,event=branch
             type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
             type=sha
+
       - name: Publish Bundle
         id: publish
         run: |


### PR DESCRIPTION
This tag format helps with automated image deployments with systems like FluxCD as new tags are introduced to a branch.