### PR TITLE
Add version tag extraction step to Docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -35,8 +35,8 @@ jobs:
           tags: |
             type=ref,event=pr
             type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-            type=ref,event=branch
             type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
+            type=ref,event=branch
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
@@ -45,7 +45,7 @@ jobs:
       - name: Extract version tag
         id: version-tag  
         run: |
-          FULL_TAG="${{ fromJSON(steps.meta.outputs.json).tags[1] }}"
+          FULL_TAG="${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
           VERSION_TAG="${FULL_TAG##*:}"
           echo "tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Added a new version-tag step that extracts the version tag from the Docker metadata output and makes it available as a build argument. This step parses the first tag from the metadata JSON, strips the image name prefix, and outputs the clean version tag for use in subsequent build steps. The extracted version is now passed to the Docker build process via the VERSION build argument, enabling proper version labeling within the container image.