### PR TITLE
feat: add build information to docker build args

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
         description: "The name of the image that should be used, excluding the repository (e.g. `cloud-portal`)"
+      extra-build-args:
+        required: false
+        type: string
+        description: "Additional build arguments to pass to docker build (multiline string format)"
 
 jobs:
   build-and-push:
@@ -62,4 +66,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ steps.version-tag.outputs.tag }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_TREE_STATE=clean
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            ${{ inputs.extra-build-args }}

--- a/docs/publish-docker/README.md
+++ b/docs/publish-docker/README.md
@@ -7,15 +7,44 @@ pushes a Docker image to **GitHub Container Registry**.
 
 ### Inputs
 
-- **image-name**: The name of the docker image (without the registry) that
+- **image-name** (required): The name of the docker image (without the registry) that
   should be used (e.g. cloud-portal).
+- **extra-build-args** (optional): Additional build arguments to pass to docker build
+  in multiline string format.
+
+### Automatic Build Arguments
+
+The workflow automatically provides the following build arguments to your Dockerfile:
+
+- **VERSION**: Generated from git tags, branch names, or commit SHA using Docker metadata action
+- **GIT_COMMIT**: The full commit SHA (`${{ github.sha }}`)
+- **GIT_TREE_STATE**: Set to `clean` (CI builds are always clean)
+- **BUILD_DATE**: The commit timestamp (`${{ github.event.head_commit.timestamp }}`)
+- **SENTRY_AUTH_TOKEN**: Passed from secrets (if available)
+
+These are commonly used for version injection in Go applications using ldflags, e.g.:
+
+```dockerfile
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=dirty
+ARG BUILD_DATE=unknown
+
+RUN go build -ldflags="-X k8s.io/component-base/version.gitVersion=${VERSION} \
+    -X k8s.io/component-base/version.gitCommit=${GIT_COMMIT} \
+    -X k8s.io/component-base/version.gitTreeState=${GIT_TREE_STATE} \
+    -X k8s.io/component-base/version.buildDate=${BUILD_DATE}" \
+    -o app ./cmd/app
+```
 
 ## Best Practices
 
 - Always use a tagged version when referencing the GitHub action workflow to
   prevent unexpected breaking changes.
 
-### **Workflow Example**
+### **Workflow Examples**
+
+#### Basic Usage
 
 Create a workflow in your repository (e.g., `.github/workflows/publish.yaml`)
 that calls this reusable action:
@@ -33,4 +62,26 @@ jobs:
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1
     with:
       image-name: my-app
+    secrets: inherit
+```
+
+#### Advanced Usage with Extra Build Arguments
+
+```yaml
+name: Publish Docker Image
+
+on:
+  push:
+  release:
+    types: ['published']
+
+jobs:
+  publish:
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1
+    with:
+      image-name: my-app
+      extra-build-args: |
+        CUSTOM_ARG=value
+        ANOTHER_ARG=${{ github.run_number }}
+    secrets: inherit
 ```


### PR DESCRIPTION
This PR updates the docker build shared action to support passing in custom build arguments to the docker build process. 

It also automatically includes git information like tree state, commit, build date, and version information so it's easily available to container images at build time. This information can be injected into binaries built by the container like go binaries using ldflags. 

### Testing

Confirmed the [Milo repo built successfully](https://github.com/datum-cloud/milo/actions/runs/17805010056/job/50614545413) when using this new action update and the metadata information was passed through as expected. 

```shell
RUN echo "Building with version: feature-local-telemetry-environment-20250917-170110, commit: 7e25006e35feb83e97bf74df9cf82de02cc346b6, tree: clean, date: 2025-09-17T12:01:10-05:00" &&     CGO_ENABLED=0 GOOS=linux GOARCH=amd64     go build     -ldflags="-w -s     -X k8s.io/component-base/version.gitVersion=feature-local-telemetry-environment-20250917-170110     -X k8s.io/component-base/version.gitCommit=7e25006e35feb83e97bf74df9cf82de02cc346b6     -X k8s.io/component-base/version.gitTreeState=clean     -X k8s.io/component-base/version.buildDate=2025-09-17T12:01:10-05:00"     -trimpath -o milo ./cmd/milo
```
