### PR TITLE
chore: add semver compliance, new outputs and build target support to workflows

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         description: "Additional build arguments to pass to docker build (multiline string format)"
+      target:
+        required: false
+        type: string
+        description: "Docker build target stage"
+        default: ""
     outputs:
       tag:
         description: "The extracted version tag"
@@ -47,14 +52,14 @@ jobs:
         with:
           images: ghcr.io/datum-cloud/${{ inputs.image-name }}
           tags: |
-            type=ref,event=pr
-            type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-            type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-            type=ref,event=branch
+            type=ref,event=pr,prefix=v0.0.0-
+            type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
+            type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
+            type=ref,event=branch,prefix=v0.0.0-
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=sha
+            type=sha,prefix=v0.0.0-
 
       - name: Extract version tag
         id: version-tag
@@ -84,6 +89,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          target: ${{ inputs.target }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -68,14 +68,14 @@ jobs:
         with:
           images: ${{ inputs.bundle-name }}
           tags: |
-            type=ref,event=pr
-            type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-            type=ref,event=branch
-            type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
+            type=ref,event=pr,prefix=v0.0.0-
+            type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
+            type=ref,event=branch,prefix=v0.0.0-
+            type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}
-            type=sha
+            type=sha,prefix=v0.0.0-
 
       - name: Set Image Tags in Kustomize Overlays
         if: ${{ inputs.image-overlays != '' && inputs.image-name != '' }}


### PR DESCRIPTION
## Add workflow outputs to publish-docker workflow

Exposes `tag` and `build-version` as workflow outputs to enable downstream jobs to reference the published image tags.

### Changes
- Added `outputs` section to `workflow_call` trigger
- Added `outputs` to `build-and-push` job to expose values from `version-tag` step

### Usage
Calling workflows can now access:
- `outputs.tag`: The extracted version tag (e.g., `main-20250925-123456` or `v1.2.3`)
- `outputs.build-version`: The semver-compliant build version

This enables downstream workflows to dynamically reference the exact image tag that was built and pushed, rather than having to reconstruct or hardcode the tag.

This PR also adds semver compliance to both the Docker and Kustomize bundle workflows by prefixing branch, PR, and SHA tags with `v0.0.0-`, enabling Flux to use semver filtering for pre-release versions. Additionally, it adds an optional `target` parameter to the Docker workflow to support multi-stage builds. These changes allow services to use semver-based OCI repository filtering instead of relying on ImageUpdateAutomation policies, simplifying the deployment process while maintaining backward compatibility with existing workflows that don't require the new parameters.