### PR TITLE
chore: prioritize timestamped tags in metadata extraction

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -52,8 +52,8 @@ jobs:
         with:
           images: ghcr.io/datum-cloud/${{ inputs.image-name }}
           tags: |
-            type=ref,event=pr,prefix=v0.0.0-
             type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
+            type=ref,event=pr,prefix=v0.0.0-
             type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
             type=ref,event=branch,prefix=v0.0.0-
             type=semver,pattern=v{{version}}

--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -68,10 +68,10 @@ jobs:
         with:
           images: ${{ inputs.bundle-name }}
           tags: |
-            type=ref,event=pr,prefix=v0.0.0-
             type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
-            type=ref,event=branch,prefix=v0.0.0-
+            type=ref,event=pr,prefix=v0.0.0-
             type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
+            type=ref,event=branch,prefix=v0.0.0-
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}


### PR DESCRIPTION
Reorder tag generation in both Docker and Kustomize workflows to prioritize timestamped tags over generic branch tags. This ensures that kustomize bundles embed the most specific image version (e.g., v0.0.0-main-20251023-172936) instead of the generic branch tag (e.g., v0.0.0-main), providing better traceability and version tracking in deployed resources.