### PR TITLE
Enforce single assignee on issues

### DIFF
--- a/.github/workflows/enforce-single-assignee.yaml
+++ b/.github/workflows/enforce-single-assignee.yaml
@@ -1,0 +1,39 @@
+name: Enforce Single Assignee
+
+on:
+  workflow_call:
+
+jobs:
+  enforce:
+    name: Enforce Single Assignee
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Enforce single assignee
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASSIGNEES: ${{ toJSON(github.event.issue.assignees) }}
+          LATEST_ASSIGNEE: ${{ github.event.assignee.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          COUNT=$(echo "$ASSIGNEES" | jq 'length')
+
+          if [ "$COUNT" -le 1 ]; then
+            echo "Issue has $COUNT assignee(s). No action needed."
+            exit 0
+          fi
+
+          echo "Issue has $COUNT assignees. Keeping '$LATEST_ASSIGNEE', removing others."
+
+          TO_REMOVE=$(echo "$ASSIGNEES" | jq --arg keep "$LATEST_ASSIGNEE" \
+            '[.[] | select(.login != $keep) | .login]')
+
+          echo "Removing: $(echo "$TO_REMOVE" | jq -r '.[]')"
+
+          gh api "repos/$REPO/issues/$ISSUE_NUMBER/assignees" \
+            -X DELETE \
+            --input - <<< "{\"assignees\": $TO_REMOVE}"
+
+          echo "Done. Issue now has 1 assignee: $LATEST_ASSIGNEE"

--- a/docs/enforce-single-assignee/README.md
+++ b/docs/enforce-single-assignee/README.md
@@ -1,0 +1,62 @@
+# Enforce Single Assignee
+
+The `.github/workflows/enforce-single-assignee.yaml` reusable GitHub Action
+enforces a maximum of one assignee per issue. When more than one assignee is
+detected, all but the most recently assigned user are automatically removed.
+
+## Usage
+
+### Inputs
+
+This workflow does not require any inputs.
+
+### Required Permissions
+
+The calling repository's GITHUB_TOKEN must have `issues: write` permission.
+This is typically granted by default, but can be explicitly set:
+
+```yaml
+permissions:
+  issues: write
+```
+
+### Behavior
+
+| Assignee count | Action taken |
+|---|---|
+| 0 or 1 | No action taken |
+| 2+ | All assignees except the most recently assigned user are removed |
+
+The most recently assigned user is determined by `github.event.assignee`,
+which GitHub populates with the user who triggered the `assigned` event.
+
+## Calling Example
+
+Create a workflow in your repository (e.g., `.github/workflows/enforce-assignees.yaml`):
+
+```yaml
+name: Enforce Single Assignee
+
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  enforce:
+    uses: datum-cloud/actions/.github/workflows/enforce-single-assignee.yaml@v1
+    secrets: inherit
+```
+
+## Troubleshooting
+
+### Workflow fails with permission error
+
+`secrets: inherit` is required in the calling workflow so that `GITHUB_TOKEN`
+is passed through to the reusable workflow. Without it, the `GH_TOKEN`
+environment variable will be empty and the GitHub API call will fail.
+
+### Workflow not triggered
+
+Verify the calling workflow is triggered on `issues: [assigned]`. Other issue
+event types (e.g., `opened`, `edited`) do not populate `github.event.assignee`
+and will not work correctly with this workflow.


### PR DESCRIPTION
## Summary

- Adds reusable workflow `enforce-single-assignee.yaml` that removes all but the latest-assigned user when an issue has more than one assignee
- Adds documentation in `docs/enforce-single-assignee/README.md`

## Motivation

Ownership of an issue is an important part of working as a team. We can use issue assignments to immediately identify who is taking responsibility:

- 0 assignees: No one. Triage the issue or otherwise archive it.
- 1 assignee: They're the owner. They shepherd the problem through to resolution, turning ambiguity into an outcome.
- 2 or more assignees: Error state. Choose the latest-assigned user. Even a tight team of two or three should have a clear owner who has the responsibility at any given time.

(If an issue needs to be handed off, supply the context in a comment and update the assignee.)

## Changes

- `.github/workflows/enforce-single-assignee.yaml` — reusable `workflow_call` workflow; triggered on `issues: [assigned]` by calling repos; uses `gh api` to DELETE extra assignees, keeping only `github.event.assignee`
- `docs/enforce-single-assignee/README.md` — usage, required permissions, behavior table, calling example, troubleshooting

## Usage

Calling repos opt in with:

```yaml
# .github/workflows/enforce-assignees.yaml
on:
  issues:
    types: [assigned]

jobs:
  enforce:
    uses: datum-cloud/actions/.github/workflows/enforce-single-assignee.yaml@v1
    secrets: inherit
```

## Testing

- [ ] Created a test issue and assigned 2+ users — workflow ran and removed all but the latest-assigned user
- [ ] Assigned 1 user — workflow exited with no action