### PR TITLE
feat: add set-project-month reusable workflow

### DIFF
--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -14,12 +14,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           PROJECT_NUMBER: 60
           PROJECT_ORG: datum-cloud
-        run: |
-          MONTH_LABEL=$(date +'%B %Y')
-          echo "Month label: $MONTH_LABEL"
-
-          # Get project ID and Month field metadata
-          FIELDS_QUERY=$(cat <<'GRAPHQL'
+          FIELDS_QUERY: |
             query($org: String!, $number: Int!) {
               organization(login: $org) {
                 projectV2(number: $number) {
@@ -36,68 +31,19 @@ jobs:
                 }
               }
             }
-GRAPHQL
-          )
-
-          PROJECT_DATA=$(gh api graphql -f query="$FIELDS_QUERY" \
-            -f org="$PROJECT_ORG" -F number="$PROJECT_NUMBER")
-
-          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.organization.projectV2.id')
-          echo "Project ID: $PROJECT_ID"
-
-          MONTH_FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '
-            .data.organization.projectV2.fields.nodes[]
-            | select(.name == "Month")
-            | .id
-          ')
-          echo "Month field ID: $MONTH_FIELD_ID"
-
-          OPTION_ID=$(echo "$PROJECT_DATA" | jq -r --arg label "$MONTH_LABEL" '
-            .data.organization.projectV2.fields.nodes[]
-            | select(.name == "Month")
-            | .options[]
-            | select(.name == $label)
-            | .id
-          ')
-
-          if [ -z "$OPTION_ID" ]; then
-            echo "No Month option found for '$MONTH_LABEL' — skipping."
-            echo "Add a '$MONTH_LABEL' option to the Month field in project $PROJECT_NUMBER to enable automation."
-            exit 0
-          fi
-          echo "Month option ID: $OPTION_ID"
-
-          # Get the PR node ID
-          PR_QUERY=$(cat <<'GRAPHQL'
+          PR_QUERY: |
             query($url: URI!) {
               resource(url: $url) {
                 ... on PullRequest { id }
               }
             }
-GRAPHQL
-          )
-
-          PR_NODE_ID=$(gh api graphql -f query="$PR_QUERY" \
-            -f url="$PR_URL" --jq '.data.resource.id')
-          echo "PR node ID: $PR_NODE_ID"
-
-          # Add PR to project (idempotent)
-          ADD_QUERY=$(cat <<'GRAPHQL'
+          ADD_QUERY: |
             mutation($projectId: ID!, $contentId: ID!) {
               addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
                 item { id }
               }
             }
-GRAPHQL
-          )
-
-          ITEM_ID=$(gh api graphql -f query="$ADD_QUERY" \
-            -f projectId="$PROJECT_ID" -f contentId="$PR_NODE_ID" \
-            --jq '.data.addProjectV2ItemById.item.id')
-          echo "Project item ID: $ITEM_ID"
-
-          # Set the Month field
-          UPDATE_QUERY=$(cat <<'GRAPHQL'
+          UPDATE_QUERY: |
             mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $projectId
@@ -108,8 +54,36 @@ GRAPHQL
                 projectV2Item { id }
               }
             }
-GRAPHQL
-          )
+        run: |
+          MONTH_LABEL=$(date +'%B %Y')
+          echo "Month label: $MONTH_LABEL"
+
+          PROJECT_DATA=$(gh api graphql -f query="$FIELDS_QUERY" \
+            -f org="$PROJECT_ORG" -F number="$PROJECT_NUMBER")
+
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.organization.projectV2.id')
+          echo "Project ID: $PROJECT_ID"
+
+          MONTH_FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Month") | .id')
+          echo "Month field ID: $MONTH_FIELD_ID"
+
+          OPTION_ID=$(echo "$PROJECT_DATA" | jq -r --arg label "$MONTH_LABEL" '.data.organization.projectV2.fields.nodes[] | select(.name == "Month") | .options[] | select(.name == $label) | .id')
+
+          if [ -z "$OPTION_ID" ]; then
+            echo "No Month option found for '$MONTH_LABEL' — skipping."
+            echo "Add a '$MONTH_LABEL' option to the Month field in project $PROJECT_NUMBER to enable automation."
+            exit 0
+          fi
+          echo "Month option ID: $OPTION_ID"
+
+          PR_NODE_ID=$(gh api graphql -f query="$PR_QUERY" \
+            -f url="$PR_URL" --jq '.data.resource.id')
+          echo "PR node ID: $PR_NODE_ID"
+
+          ITEM_ID=$(gh api graphql -f query="$ADD_QUERY" \
+            -f projectId="$PROJECT_ID" -f contentId="$PR_NODE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+          echo "Project item ID: $ITEM_ID"
 
           gh api graphql -f query="$UPDATE_QUERY" \
             -f projectId="$PROJECT_ID" \

--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -15,6 +15,7 @@ jobs:
           PROJECT_NUMBER: 60
           PROJECT_ORG: datum-cloud
         run: |
+          # shellcheck disable=SC2016  # GraphQL uses $var syntax inside single-quoted strings; not shell vars
           # Compute current month label e.g. "April 2026"
           MONTH_LABEL=$(date +'%B %Y')
           echo "Month label: $MONTH_LABEL"

--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -1,0 +1,105 @@
+name: Set Project Month
+
+on:
+  workflow_call:
+
+jobs:
+  set-month:
+    name: Set project month field
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set month field on project
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PROJECT_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PROJECT_NUMBER: 60
+          PROJECT_ORG: datum-cloud
+        run: |
+          # Compute current month label e.g. "April 2026"
+          MONTH_LABEL=$(date +'%B %Y')
+          echo "Month label: $MONTH_LABEL"
+
+          # Get project ID and Month field metadata
+          PROJECT_DATA=$(gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org) {
+                projectV2(number: $number) {
+                  id
+                  fields(first: 30) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f org="$PROJECT_ORG" -F number="$PROJECT_NUMBER")
+
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.organization.projectV2.id')
+          echo "Project ID: $PROJECT_ID"
+
+          MONTH_FIELD_ID=$(echo "$PROJECT_DATA" | jq -r '
+            .data.organization.projectV2.fields.nodes[]
+            | select(.name == "Month")
+            | .id
+          ')
+          echo "Month field ID: $MONTH_FIELD_ID"
+
+          OPTION_ID=$(echo "$PROJECT_DATA" | jq -r --arg label "$MONTH_LABEL" '
+            .data.organization.projectV2.fields.nodes[]
+            | select(.name == "Month")
+            | .options[]
+            | select(.name == $label)
+            | .id
+          ')
+
+          if [ -z "$OPTION_ID" ]; then
+            echo "No Month option found for '$MONTH_LABEL' — skipping."
+            echo "Add a '$MONTH_LABEL' option to the Month field in project $PROJECT_NUMBER to enable automation."
+            exit 0
+          fi
+          echo "Month option ID: $OPTION_ID"
+
+          # Get the PR node ID
+          PR_NODE_ID=$(gh api graphql -f query='
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on PullRequest { id }
+              }
+            }
+          ' -f url="$PR_URL" --jq '.data.resource.id')
+          echo "PR node ID: $PR_NODE_ID"
+
+          # Add PR to project (idempotent)
+          ITEM_ID=$(gh api graphql -f query='
+            mutation($projectId: ID!, $contentId: ID!) {
+              addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f contentId="$PR_NODE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id')
+          echo "Project item ID: $ITEM_ID"
+
+          # Set the Month field
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" \
+            -f itemId="$ITEM_ID" \
+            -f fieldId="$MONTH_FIELD_ID" \
+            -f optionId="$OPTION_ID"
+
+          echo "Done — PR added to project $PROJECT_NUMBER with Month = $MONTH_LABEL"

--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -15,13 +15,11 @@ jobs:
           PROJECT_NUMBER: 60
           PROJECT_ORG: datum-cloud
         run: |
-          # shellcheck disable=SC2016  # GraphQL uses $var syntax inside single-quoted strings; not shell vars
-          # Compute current month label e.g. "April 2026"
           MONTH_LABEL=$(date +'%B %Y')
           echo "Month label: $MONTH_LABEL"
 
           # Get project ID and Month field metadata
-          PROJECT_DATA=$(gh api graphql -f query='
+          FIELDS_QUERY=$(cat <<'GRAPHQL'
             query($org: String!, $number: Int!) {
               organization(login: $org) {
                 projectV2(number: $number) {
@@ -38,7 +36,11 @@ jobs:
                 }
               }
             }
-          ' -f org="$PROJECT_ORG" -F number="$PROJECT_NUMBER")
+GRAPHQL
+          )
+
+          PROJECT_DATA=$(gh api graphql -f query="$FIELDS_QUERY" \
+            -f org="$PROJECT_ORG" -F number="$PROJECT_NUMBER")
 
           PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r '.data.organization.projectV2.id')
           echo "Project ID: $PROJECT_ID"
@@ -66,28 +68,36 @@ jobs:
           echo "Month option ID: $OPTION_ID"
 
           # Get the PR node ID
-          PR_NODE_ID=$(gh api graphql -f query='
+          PR_QUERY=$(cat <<'GRAPHQL'
             query($url: URI!) {
               resource(url: $url) {
                 ... on PullRequest { id }
               }
             }
-          ' -f url="$PR_URL" --jq '.data.resource.id')
+GRAPHQL
+          )
+
+          PR_NODE_ID=$(gh api graphql -f query="$PR_QUERY" \
+            -f url="$PR_URL" --jq '.data.resource.id')
           echo "PR node ID: $PR_NODE_ID"
 
           # Add PR to project (idempotent)
-          ITEM_ID=$(gh api graphql -f query='
+          ADD_QUERY=$(cat <<'GRAPHQL'
             mutation($projectId: ID!, $contentId: ID!) {
               addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
                 item { id }
               }
             }
-          ' -f projectId="$PROJECT_ID" -f contentId="$PR_NODE_ID" \
+GRAPHQL
+          )
+
+          ITEM_ID=$(gh api graphql -f query="$ADD_QUERY" \
+            -f projectId="$PROJECT_ID" -f contentId="$PR_NODE_ID" \
             --jq '.data.addProjectV2ItemById.item.id')
           echo "Project item ID: $ITEM_ID"
 
           # Set the Month field
-          gh api graphql -f query='
+          UPDATE_QUERY=$(cat <<'GRAPHQL'
             mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $projectId
@@ -98,7 +108,11 @@ jobs:
                 projectV2Item { id }
               }
             }
-          ' -f projectId="$PROJECT_ID" \
+GRAPHQL
+          )
+
+          gh api graphql -f query="$UPDATE_QUERY" \
+            -f projectId="$PROJECT_ID" \
             -f itemId="$ITEM_ID" \
             -f fieldId="$MONTH_FIELD_ID" \
             -f optionId="$OPTION_ID"


### PR DESCRIPTION
## Summary

- Adds a reusable workflow that automatically adds a PR to the datum-cloud org project and sets the **Month** field based on the current calendar month (e.g. `April 2026`)
- Month option is resolved dynamically at runtime — no hardcoded IDs, works month-to-month as long as the option exists in the project
- Gracefully skips (exit 0) if no matching Month option is found, so PRs are never blocked
- Uses `ORG_PROJECT_TOKEN` org secret for project write access (classic PAT with `project` scope)

## Usage

Consumers opt in with a small workflow file:

\`\`\`yaml
name: Set Project Month

on:
  pull_request:
    types: [opened, ready_for_review, reopened]

jobs:
  set-month:
    uses: datum-cloud/actions/.github/workflows/set-project-month.yaml@main
    secrets: inherit
\`\`\`

First consumer PRs will follow for: `cloud-portal`, `staff-portal`, `infra`, `milo`.

## Test plan

- [ ] Merge this PR
- [ ] Confirm `ORG_PROJECT_TOKEN` org secret is set with a PAT that has `project` scope
- [ ] Open a test PR in a consumer repo and verify it appears in project 60 with the correct Month set