### PR TITLE
feat: switch set-project-month to GitHub App token

### DIFF
--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -8,9 +8,17 @@ jobs:
     name: Set project month field
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DATUM_PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.DATUM_PROJECT_AUTOMATION_PRIVATE_KEY }}
+          owner: datum-cloud
+
       - name: Set month field on project
         env:
-          GH_TOKEN: ${{ secrets.ORG_PROJECT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PROJECT_NUMBER: 60
           PROJECT_ORG: datum-cloud


### PR DESCRIPTION
## Summary

- Replaces `ORG_PROJECT_TOKEN` (PAT) with a short-lived token minted via `actions/create-github-app-token@v1`
- Requires two org secrets:
  - `DATUM_PROJECT_AUTOMATION_APP_ID` — the numeric GitHub App ID
  - `DATUM_PROJECT_AUTOMATION_PRIVATE_KEY` — the app's private key (`.pem` contents)
- No changes needed in consumer repos — they just `secrets: inherit`

## Test plan

- [ ] Confirm `DATUM_PROJECT_AUTOMATION_APP_ID` and `DATUM_PROJECT_AUTOMATION_PRIVATE_KEY` org secrets are set
- [ ] Confirm the GitHub App is installed on `datum-cloud` org with Projects read/write permission
- [ ] Open a test PR in a consumer repo and verify it appears in project #60 with the correct Month set