### PR TITLE
fix: remove manual kustomize install steps

### DIFF
--- a/.github/workflows/publish-kustomize-bundle.yaml
+++ b/.github/workflows/publish-kustomize-bundle.yaml
@@ -62,11 +62,6 @@ jobs:
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@v2.7.5
       
-      - name: Install Kustomize
-        run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-          sudo mv kustomize /usr/local/bin/
-      
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/validate-kustomize.yaml
+++ b/.github/workflows/validate-kustomize.yaml
@@ -15,11 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install Kustomize
-      run: |
-        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
-        sudo mv kustomize /usr/local/bin/
-
     - name: Find and validate Kustomize configurations
       id: validate
       run: |


### PR DESCRIPTION
## Summary
- Remove the `Install Kustomize` steps from `validate-kustomize` and `publish-kustomize-bundle` workflows
- Kustomize 5.8.1 is already pre-installed on `ubuntu-latest` runners
- The curl-based install from the upstream `master` branch broke when the download pattern changed and is also susceptible to GitHub rate limits

## Test plan
- [ ] Verify `validate-kustomize` job passes without the install step
- [ ] Verify `publish-kustomize-bundle` job passes without the install step

Relates to https://github.com/datum-cloud/infra/issues/1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)