### PR TITLE
feat: add configurable registry-organization input to publish-docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -31,6 +31,11 @@ on:
         type: string
         description: "Comma separated list of target platforms for multi-arch builds"
         default: "linux/amd64"
+      registry-organization:
+        required: false
+        type: string
+        description: "The GitHub organization used in the container registry path (e.g. `milo-os`). Defaults to `datum-cloud`."
+        default: "datum-cloud"
     outputs:
       tag:
         description: "The extracted version tag"
@@ -65,7 +70,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/datum-cloud/${{ inputs.image-name }}
+          images: ghcr.io/${{ inputs.registry-organization }}/${{ inputs.image-name }}
           tags: |
             type=ref,event=pr,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}},prefix=v0.0.0-
             type=ref,event=pr,prefix=v0.0.0-

--- a/docs/publish-docker/README.md
+++ b/docs/publish-docker/README.md
@@ -9,6 +9,8 @@ pushes a Docker image to **GitHub Container Registry**.
 
 - **image-name** (required): The name of the docker image (without the registry) that
   should be used (e.g. cloud-portal).
+- **registry-organization** (optional): The GitHub organization used in the container
+  registry path (e.g. `milo-os`). Defaults to `datum-cloud`.
 - **extra-build-args** (optional): Additional build arguments to pass to docker build
   in multiline string format.
 


### PR DESCRIPTION
## Summary

- Adds an optional `registry-organization` workflow input to `.github/workflows/publish-docker.yaml`, replacing the hardcoded `datum-cloud` in the `docker/metadata-action` `images:` field.
- The input defaults to `datum-cloud`, so all existing callers continue to work without modification.
- Updates `docs/publish-docker/README.md` to document the new input alongside existing ones.

## Backward compatibility

Existing callers that do not pass `registry-organization` will continue publishing to `ghcr.io/datum-cloud/<image-name>` — no changes required on their side.

## Test plan

- [ ] Verify an existing caller (no `registry-organization` input) still produces images under `ghcr.io/datum-cloud/`.
- [ ] Verify a caller passing `registry-organization: milo-os` produces images under `ghcr.io/milo-os/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)