### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @datum-cloud/engineering


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file that assigns `@datum-cloud/engineering` as the code owner for all files in this repository. This ensures the team is automatically added as a reviewer on every pull request.