### PR TITLE
feat: add reusable generate-doc-toc workflow

### DIFF
--- a/.github/workflows/generate-doc-toc.yaml
+++ b/.github/workflows/generate-doc-toc.yaml
@@ -1,0 +1,50 @@
+name: Generate Doc TOC
+
+on:
+  workflow_call:
+    inputs:
+      docs-path:
+        description: Path to the directory containing markdown docs
+        type: string
+        default: docs/
+      node-version:
+        description: Node.js version to use
+        type: string
+        default: "20"
+
+permissions:
+  contents: write
+
+jobs:
+  generate-toc:
+    name: Generate TOC
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install doctoc
+        run: npm install -g doctoc
+
+      - name: Generate TOCs
+        run: doctoc ${{ inputs.docs-path }} --github --title "## Contents"
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "${{ inputs.docs-path }}"
+          if git diff --staged --quiet; then
+            echo "No TOC changes detected."
+          else
+            git commit -m "docs: regenerate table of contents [skip ci]"
+            git push
+          fi

--- a/docs/generate-doc-toc/README.md
+++ b/docs/generate-doc-toc/README.md
@@ -1,0 +1,82 @@
+# Generate Doc TOC
+
+The `.github/workflows/generate-doc-toc.yaml` reusable GitHub Action generates
+and maintains tables of contents for markdown documentation using
+[doctoc](https://github.com/thlorenz/doctoc). When docs change on the main
+branch, it regenerates the TOC and commits the result automatically.
+
+## 🚀 Usage
+
+### Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `docs-path` | No | `docs/` | Path to the directory containing markdown docs |
+| `node-version` | No | `20` | Node.js version to use |
+
+### Required Permissions
+
+```yaml
+permissions:
+  contents: write
+```
+
+### Basic Usage
+
+```yaml
+name: Generate Doc TOC
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**/*.md"
+
+jobs:
+  generate-toc:
+    uses: datum-cloud/actions/.github/workflows/generate-doc-toc.yaml@main
+    permissions:
+      contents: write
+```
+
+### Custom Docs Path
+
+```yaml
+jobs:
+  generate-toc:
+    uses: datum-cloud/actions/.github/workflows/generate-doc-toc.yaml@main
+    with:
+      docs-path: content/docs/
+    permissions:
+      contents: write
+```
+
+## How It Works
+
+1. Checks out the repository at the current branch.
+2. Installs `doctoc` via npm.
+3. Runs `doctoc` against the docs directory. On first run, doctoc inserts TOC
+   marker comments into each file. On subsequent runs it updates the TOC in place.
+4. If any files changed, commits them back to the branch with `[skip ci]` to
+   avoid triggering another workflow run.
+
+TOC markers look like this and are added automatically on first run:
+
+```markdown
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Contents
+
+- [Section One](#section-one)
+- [Section Two](#section-two)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+```
+
+## Best Practices
+
+- Trigger only on pushes to `main` (not PRs) to avoid commit conflicts on
+  short-lived branches.
+- Use the `paths` filter to limit runs to actual doc changes.
+- The `[skip ci]` suffix on the commit message prevents the push from
+  triggering another workflow run.


### PR DESCRIPTION
## Summary

Adds a reusable workflow that generates and maintains tables of contents for markdown documentation directories using [doctoc](https://github.com/thlorenz/doctoc).

When triggered, it installs doctoc, runs it against the configured docs path, and commits any changes back to the branch with `[skip ci]`. On first run it inserts TOC marker comments into each file; on subsequent runs it updates them in place.

## Inputs

| Input | Default | Description |
|---|---|---|
| `docs-path` | `docs/` | Directory containing markdown docs |
| `node-version` | `20` | Node.js version |

## Usage

```yaml
jobs:
  generate-toc:
    uses: datum-cloud/actions/.github/workflows/generate-doc-toc.yaml@main
    permissions:
      contents: write
```