### PR TITLE
fix(generate-doc-toc): open PR instead of pushing to main

### DIFF
--- a/.github/workflows/generate-doc-toc.yaml
+++ b/.github/workflows/generate-doc-toc.yaml
@@ -11,9 +11,22 @@ on:
         description: Node.js version to use
         type: string
         default: "20"
+      branch-name:
+        description: Name of the branch the PR is opened from
+        type: string
+        default: auto/regenerate-doc-toc
+      pr-title:
+        description: Title for the pull request
+        type: string
+        default: "docs: regenerate table of contents"
+      pr-labels:
+        description: Comma-separated labels to apply to the PR
+        type: string
+        default: documentation,automated
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate-toc:
@@ -23,8 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -37,14 +48,16 @@ jobs:
       - name: Generate TOCs
         run: doctoc ${{ inputs.docs-path }} --github --title "## Contents"
 
-      - name: Commit changes
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "${{ inputs.docs-path }}"
-          if git diff --staged --quiet; then
-            echo "No TOC changes detected."
-          else
-            git commit -m "docs: regenerate table of contents [skip ci]"
-            git push
-          fi
+      - name: Open pull request with TOC updates
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: ${{ inputs.branch-name }}
+          commit-message: "docs: regenerate table of contents"
+          title: ${{ inputs.pr-title }}
+          body: |
+            Auto-generated table of contents updates from `doctoc`.
+
+            Triggered by `${{ github.event_name }}` on `${{ github.ref_name }}` (${{ github.sha }}).
+          labels: ${{ inputs.pr-labels }}
+          delete-branch: true
+          sign-commits: true


### PR DESCRIPTION
## Summary
- Swap the manual `git commit && git push` step for `peter-evans/create-pull-request@v8` so the workflow no longer tries to push directly to the calling repo's default branch.
- Add `pull-requests: write` permission and expose `branch-name`, `pr-title`, and `pr-labels` inputs so consumers can customize the PR.
- Drop the explicit `ref` checkout — `create-pull-request` handles branching off the default ref itself.

## Why
The first manual run against `datum-cloud/engineering` failed because the repository ruleset blocks direct pushes to `main`:

> remote: error: GH013: Repository rule violations found for refs/heads/main.
> remote: - Changes must be made through a pull request.

Routing the regenerated TOC through a PR matches the rest of our automation (e.g. Renovate) and keeps the workflow usable on protected repos.

## Test plan
- [ ] Merge this PR and re-run `Generate Doc TOC` workflow_dispatch in `datum-cloud/engineering` — confirm a PR is opened on `auto/regenerate-doc-toc` instead of a push to `main`.
- [ ] Confirm the resulting PR carries the `documentation,automated` labels and a sensible body.