### PR TITLE
fix(bump-npm-version): land bump commit on main, not detached HEAD

### DIFF
--- a/.github/workflows/bump-npm-version.yaml
+++ b/.github/workflows/bump-npm-version.yaml
@@ -40,6 +40,12 @@ jobs:
         with:
           ref: main
 
+      # actions/checkout leaves HEAD detached. npm version creates its commit
+      # on HEAD, so we need to be on the main branch ref for that commit to
+      # advance main and get pushed.
+      - name: Switch to main branch
+        run: git checkout main
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -76,4 +82,14 @@ jobs:
           npm version "$BUMP_TYPE" --message "chore: release ${PACKAGE_NAME} v%s [skip ci]"
 
       - name: Push
-        run: git push origin main --follow-tags
+        run: |
+          # Guard: refuse to push if npm version didn't actually advance main.
+          # Prevents silently republishing the previous version downstream.
+          LOCAL=$(git rev-parse HEAD)
+          REMOTE=$(git rev-parse origin/main)
+          if [ "$LOCAL" = "$REMOTE" ]; then
+            echo "::error::npm version did not create a new commit on main; refusing to push a no-op."
+            exit 1
+          fi
+          git push origin main
+          git push origin --tags


### PR DESCRIPTION
## Summary

Fixes #71.

`actions/checkout` leaves `HEAD` detached at the requested SHA. `npm version` then creates the bump commit on the detached `HEAD`, leaving local `main` unchanged. The subsequent `git push origin main --follow-tags` reports `Everything up-to-date` and only pushes the annotated tag — pointing at the pre-bump SHA. Callers see `new-version` set and a tag on origin, but `package.json` on `main` is unchanged, and downstream publish jobs republish the previous version. See the issue for a real-world repro from `milo-os/activity`.

## Change

- Add an explicit `git checkout main` after `actions/checkout` so the bump commit advances the local `main` branch.
- Split the push so `main` and tags are pushed explicitly (no longer rely on `--follow-tags` for correctness).
- Add a guard that fails the job if `HEAD` didn't advance past `origin/main`, so any future regression surfaces loudly instead of silently republishing.

## Test plan

- [ ] Bump the caller (`milo-os/activity` → `publish-ui-npm.yaml`) to a SHA-pinned ref of this PR, run `workflow_dispatch` with `bump-type: patch`, confirm `ui/package.json` on `main` advances and the new tag points at the bump commit.
- [ ] Run `workflow_dispatch` again on a clean tree to confirm normal happy-path still works.
- [ ] (Negative) Temporarily comment out the `Bump version` step and confirm the `Push` guard fails the job with the no-op error.