### PR TITLE
fix(nix): push hash update directly to triggering branch

### DIFF
--- a/.github/workflows/nix-update-hash.yaml
+++ b/.github/workflows/nix-update-hash.yaml
@@ -15,26 +15,13 @@ on:
         description: Path to flake.nix to check for changes
         type: string
         default: flake.nix
-      pr-branch:
-        description: Head branch name for the created PR
-        type: string
-        default: nix/update-vendorhash
       commit-message:
         description: Commit message for the vendorHash change
         type: string
         default: "chore(nix): update vendorHash for go deps"
-      pr-title:
-        description: Pull request title
-        type: string
-        default: "chore(nix): update vendorHash for go deps"
-      pr-body:
-        description: Pull request body
-        type: string
-        default: "Automated vendorHash update for Go module dependency changes."
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update-hash:
@@ -61,19 +48,11 @@ jobs:
       - name: Update nix vendor hash
         run: task ${{ inputs.task-command }}
 
-      - name: Check for changes
-        id: git-check
+      - name: Commit and push changes
         run: |
-          git diff --exit-code ${{ inputs.flake-path }} || echo "changed=true" >> $GITHUB_OUTPUT
-
-      - name: Create Pull Request
-        if: steps.git-check.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: ${{ inputs.commit-message }}
-          branch: ${{ inputs.pr-branch }}
-          branch-suffix: timestamp
-          base: ${{ github.ref_name }}
-          title: ${{ inputs.pr-title }}
-          body: ${{ inputs.pr-body }}
+          git diff --exit-code ${{ inputs.flake-path }} && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ${{ inputs.flake-path }}
+          git commit -m "${{ inputs.commit-message }}"
+          git push

--- a/docs/nix-update-hash/README.md
+++ b/docs/nix-update-hash/README.md
@@ -2,8 +2,8 @@
 
 The `.github/workflows/nix-update-hash.yaml` reusable GitHub Action
 automatically updates the `vendorHash` in `flake.nix` when Go dependencies
-change. It opens a pull request targeting the branch that triggered the
-workflow, keeping the dependency update and hash fix in the same review.
+change, committing the result directly back to the branch that triggered the
+workflow.
 
 ## Prerequisites
 
@@ -24,18 +24,14 @@ for a reference implementation.
 |---|---|---|---|
 | `go-version-file` | No | `go.mod` | Path to `go.mod`, used by `actions/setup-go` |
 | `task-command` | No | `nix-update-hash` | Task command to run from the calling repo's `Taskfile.yml` |
-| `flake-path` | No | `flake.nix` | Path to `flake.nix` checked for changes after the task runs |
-| `pr-branch` | No | `nix/update-vendorhash` | Head branch for the opened PR (a timestamp suffix is appended) |
+| `flake-path` | No | `flake.nix` | Path to `flake.nix` to check and commit after the task runs |
 | `commit-message` | No | `chore(nix): update vendorHash for go deps` | Commit message |
-| `pr-title` | No | `chore(nix): update vendorHash for go deps` | Pull request title |
-| `pr-body` | No | `Automated vendorHash update for Go module dependency changes.` | Pull request body |
 
 ## Required Permissions
 
 ```yaml
 permissions:
   contents: write
-  pull-requests: write
 ```
 
 ## Usage
@@ -52,7 +48,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update-hash:
@@ -66,16 +61,15 @@ jobs:
 2. Installs Nix, Go, and Task.
 3. Runs `task <task-command>` — the calling repo's script recomputes
    `vendorHash` and writes it back to `flake.nix`.
-4. Diffs `flake.nix` — if unchanged, the workflow exits cleanly with no PR.
-5. Opens a pull request from a timestamped branch (e.g.
-   `nix/update-vendorhash-20240601-120000`) targeting **the branch that
-   triggered the workflow**. This ensures the hash fix travels with the
-   dependency update in the same PR review rather than landing separately on
-   `main`.
+4. Diffs `flake.nix` — if unchanged, exits cleanly with no commit.
+5. Commits the updated `flake.nix` and pushes directly to the triggering
+   branch, keeping the hash fix in the same branch as the dependency update.
 
 ## Best Practices
 
 - Trigger on `push` with `paths: [go.mod, go.sum]` so the workflow only runs
   when Go dependencies actually change.
 - Use `secrets: inherit` so `GITHUB_TOKEN` is available to both Nix and the
-  `create-pull-request` action.
+  push step.
+- This workflow pushes directly to the triggering branch. Do not trigger it on
+  `main` — `go.mod` changes should always arrive via a pull request branch.


### PR DESCRIPTION
## Summary

Follows up on #75 — the original PR used `peter-evans/create-pull-request` which opened a separate PR targeting `main`. That's wrong: `go.mod` should never change directly on `main`, so the workflow will always be triggered from a feature or Renovate branch where a direct `git push` is permitted.

- Replaces `peter-evans/create-pull-request` with a direct `git push` back to the triggering branch
- Removes the now-unnecessary `pr-branch`, `pr-title`, and `pr-body` inputs
- Drops `pull-requests: write` permission — only `contents: write` is needed
- Updates docs to reflect the push-based approach and note that this workflow should not be triggered on `main`