### PR TITLE
feat(validate-kustomize): build with LoadRestrictionsNone by default

### DIFF
--- a/.github/workflows/validate-kustomize.yaml
+++ b/.github/workflows/validate-kustomize.yaml
@@ -4,6 +4,14 @@ name: Validate Kustomize Configurations
 on:
   # Allow the workflow to be re-used in other repos.
   workflow_call:
+    inputs:
+      load-restrictor:
+        description: >-
+          kustomize --load-restrictor value. Defaults to LoadRestrictionsNone
+          to match Flux's kustomize-controller, so overlays that reference files
+          outside their own directory validate the same way they deploy.
+        type: string
+        default: LoadRestrictionsNone
   push:
     paths:
       - ".github/workflows/*.yaml"
@@ -17,7 +25,11 @@ jobs:
 
     - name: Find and validate Kustomize configurations
       id: validate
+      env:
+        # Empty on push events (workflow_call inputs are unset there); fall back below.
+        LOAD_RESTRICTOR: ${{ inputs.load-restrictor }}
       run: |
+        LOAD_RESTRICTOR="${LOAD_RESTRICTOR:-LoadRestrictionsNone}"
         echo "# Kustomize Validation Results"
         echo ""
         {
@@ -41,7 +53,7 @@ jobs:
         # Test each kustomization
         for dir in ${KUSTOMIZATION_DIRS}; do
           echo "🔍 Validating: ${dir}"
-          if ! OUTPUT=$(kustomize build "${dir}" --enable-helm 2>&1); then
+          if ! OUTPUT=$(kustomize build "${dir}" --enable-helm --load-restrictor "${LOAD_RESTRICTOR}" 2>&1); then
             echo ""
             echo "❌ Error in '${dir}':"
             echo "----------------------------------------"


### PR DESCRIPTION
## Why

Our Kustomize validation check and our actual deployments disagreed about what a "valid" config looks like — and validation was the stricter of the two.

Flux deploys our manifests with no path restrictions, so an overlay can reuse shared files (for example, pointing at the shared CRD definitions in `../bases/` instead of keeping its own copy). That deploys cleanly. But the CI check built those same overlays with Kustomize's strict default, which forbids reaching outside a folder — so it failed configs that ship to production every day.

The practical cost: teams either duplicate files just to satisfy CI (which then quietly drift out of sync), or their valid config is blocked on a red check that doesn't reflect reality.

## What changed

The validation check now builds configs the same way Flux deploys them, so "passes CI" once again means "will deploy." Overlays can share files across folders without duplication, and the check stops flagging configs that are actually fine.

Teams that want the stricter behavior can still opt back in via a `load-restrictor` input — the default just now matches how things really deploy.

## Rollout

This workflow is shared across repos and pinned by version tag. Once it's merged and a new tag is cut, repos pick it up by bumping their tag reference. First in line: `network-services-operator`, whose CRD overlay is blocked on this exact mismatch today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)