### PR TITLE
feat(setup-datumctl): reusable action to install and authenticate datumctl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,28 @@ Validates workflow YAML files using actionlint. Runs automatically on workflow f
 
 Finds and validates all `kustomization.yaml` files in the repository using `kustomize build --enable-helm`.
 
+### 6. Setup datumctl (`setup-datumctl/action.yaml`)
+
+Composite action (not a reusable workflow) that installs `datumctl` and authenticates a Datum service account. Used as a step inside a job, like `google-github-actions/setup-gcloud`.
+
+**Inputs:**
+- `version` (optional, default `v0.15.0`): datumctl release tag to install
+- `auth-hostname` (optional, default `auth.datum.net`): Datum auth server hostname
+- `credentials` (required): service account credentials JSON, raw or base64-encoded
+
+**Outputs:**
+- `version`: installed datumctl version
+- `bin-path`: directory datumctl was installed into and added to `PATH`
+
+Installs the released tarball for the runner's OS/arch (Linux/macOS, x86_64/arm64), verifies the SHA-256 checksum, places the binary on `PATH` without `sudo`, then logs in. The login session lives in the datumctl keyring for subsequent `datumctl`/`kubectl` steps.
+
+**Usage:**
+```yaml
+- uses: datum-cloud/actions/setup-datumctl@v1
+  with:
+    credentials: ${{ secrets.DATUM_SA_CREDENTIALS }}
+```
+
 ## Common Development Commands
 
 ### Linting Workflows

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,15 @@ available for use across the organization.
 - [**Lint GitHub Actions Workflows**](./lint-workflows/) - Validate workflow files using actionlint to catch errors and best practice violations
 - [**Validate Kustomize Configurations**](./validate-kustomize/) - Validate all Kustomize configurations by building them and checking for errors
 
+### Tooling
+
+- [**Setup datumctl**](./setup-datumctl/) - Install datumctl and authenticate a Datum service account for use in subsequent steps (composite action)
+
 ## Usage
+
+Most actions in this repo are reusable *workflows*, referenced via `uses:` at
+the job level. [Setup datumctl](./setup-datumctl/) is a *composite action* —
+add it as a step inside your own job. See its documentation for details.
 
 All workflows are designed to be used as reusable workflows. Reference them in your repository workflows using:
 

--- a/docs/setup-datumctl/README.md
+++ b/docs/setup-datumctl/README.md
@@ -1,0 +1,89 @@
+# Setup datumctl
+
+Installs [`datumctl`](https://www.datum.net/docs/cli/) and authenticates a Datum
+service account, storing the session in the datumctl keyring so subsequent
+`datumctl` and `kubectl` steps run against your Datum projects without
+re-supplying the key.
+
+Unlike the reusable *workflows* in this repo, this is a **composite action** —
+add it as a step inside one of your own jobs, the same way you would use
+[`google-github-actions/setup-gcloud`](https://github.com/google-github-actions/setup-gcloud).
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `version` | No | `v0.15.0` | datumctl version to install, given as a datumctl release tag. |
+| `auth-hostname` | No | `auth.datum.net` | Datum auth server hostname. |
+| `credentials` | **Yes** | — | Service account credentials JSON. Accepts raw JSON **or** a base64-encoded copy of it. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The datumctl version that was installed. |
+| `bin-path` | Directory datumctl was installed into and added to `PATH`. |
+
+## Platforms
+
+Installs the released tarball for the runner's OS/architecture:
+
+| OS | Architectures |
+|----|---------------|
+| Linux | `x86_64`, `arm64` |
+| macOS | `x86_64` (Intel), `arm64` (Apple Silicon) |
+
+The download is verified against the release's published SHA-256 checksum before
+it is installed. datumctl is placed in a job-scoped directory and added to
+`PATH`; no `sudo` is required.
+
+## Usage
+
+```yaml
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup datumctl
+        uses: datum-cloud/actions/setup-datumctl@v1
+        with:
+          credentials: ${{ secrets.DATUM_SA_CREDENTIALS }}
+
+      # datumctl is now on PATH and authenticated.
+      - run: datumctl auth update-kubeconfig --organization my-org
+      - run: kubectl get projects
+```
+
+### Pinning a version and selecting an auth host
+
+```yaml
+      - name: Setup datumctl
+        uses: datum-cloud/actions/setup-datumctl@v1
+        with:
+          version: v0.15.0
+          auth-hostname: auth.staging.env.datum.net
+          credentials: ${{ secrets.DATUM_SA_CREDENTIALS_STAGING }}
+```
+
+## Credentials
+
+Create a service account in the [Datum Cloud portal](https://app.datum.net)
+under your organization's IAM settings, choose **Datum-managed key**, and
+download the credentials JSON (shown only once). Store it as a repository or
+environment secret and pass it via `credentials`.
+
+The action tolerates the secret being stored either as raw JSON or
+base64-encoded — useful when a secret store mangles multi-line JSON. The value
+is written to a temporary file with mode `600` and removed after login; the
+authenticated session lives in the datumctl keyring (file backend on headless
+runners).
+
+## Best Practices
+
+- **Pin a version**: reference this action with a release tag (e.g. `@v1`) and
+  pin `version` to a known datumctl release for reproducible runs.
+- **Least privilege**: grant the service account only the roles the workflow
+  needs.
+- **Use secrets, not literals**: never inline credentials in the workflow file.

--- a/setup-datumctl/action.yaml
+++ b/setup-datumctl/action.yaml
@@ -1,0 +1,129 @@
+name: Setup datumctl
+description: >-
+  Install datumctl and authenticate a Datum service account so that subsequent
+  datumctl and kubectl steps run against your Datum projects.
+author: Datum Cloud
+
+branding:
+  icon: terminal
+  color: blue
+
+inputs:
+  version:
+    description: >-
+      datumctl version to install, given as a datumctl release tag
+      (e.g. v0.15.0).
+    required: false
+    default: v0.15.0
+  auth-hostname:
+    description: Datum auth server hostname (e.g. auth.datum.net).
+    required: false
+    default: auth.datum.net
+  credentials:
+    description: >-
+      Datum service account credentials JSON. Accepts either the raw JSON or a
+      base64-encoded copy of it. Store it in a secret and pass it here; the
+      value is written to a temporary file (mode 600) and removed after login.
+    required: true
+
+outputs:
+  version:
+    description: The datumctl version that was installed.
+    value: ${{ steps.install.outputs.version }}
+  bin-path:
+    description: Directory datumctl was installed into and added to PATH.
+    value: ${{ steps.install.outputs.bin-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install datumctl
+      id: install
+      shell: bash
+      env:
+        DATUMCTL_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        version="${DATUMCTL_VERSION}"
+        # Release tags carry a leading "v"; checksum file names do not.
+        version_no_v="${version#v}"
+
+        os=$(uname -s)
+        arch=$(uname -m)
+        case "${os}/${arch}" in
+          Linux/x86_64) asset=datumctl_Linux_x86_64.tar.gz ;;
+          Linux/aarch64 | Linux/arm64) asset=datumctl_Linux_arm64.tar.gz ;;
+          Darwin/arm64) asset=datumctl_Darwin_arm64.tar.gz ;;
+          Darwin/x86_64) asset=datumctl_Darwin_x86_64.tar.gz ;;
+          *)
+            echo "::error::unsupported platform: ${os}/${arch}" >&2
+            exit 1
+            ;;
+        esac
+
+        base="https://github.com/datum-cloud/datumctl/releases/download/${version}"
+        tmp=$(mktemp -d)
+        trap 'rm -rf "${tmp}"' EXIT
+
+        echo "Downloading datumctl ${version} (${asset})"
+        curl -fsSL -o "${tmp}/${asset}" "${base}/${asset}"
+        curl -fsSL -o "${tmp}/checksums.txt" \
+          "${base}/datumctl_${version_no_v}_checksums.txt"
+
+        # Verify the download against the published checksum before extracting.
+        expected=$(grep " ${asset}\$" "${tmp}/checksums.txt" | awk '{print $1}')
+        if [ -z "${expected}" ]; then
+          echo "::error::no checksum found for ${asset} in release ${version}" >&2
+          exit 1
+        fi
+        if command -v sha256sum >/dev/null 2>&1; then
+          actual=$(sha256sum "${tmp}/${asset}" | awk '{print $1}')
+        else
+          actual=$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')
+        fi
+        if [ "${expected}" != "${actual}" ]; then
+          echo "::error::checksum mismatch for ${asset}: expected ${expected}, got ${actual}" >&2
+          exit 1
+        fi
+
+        tar -xzf "${tmp}/${asset}" -C "${tmp}" datumctl
+
+        bindir="${RUNNER_TEMP}/datumctl-bin"
+        mkdir -p "${bindir}"
+        install "${tmp}/datumctl" "${bindir}/datumctl"
+
+        # Put datumctl on PATH for the rest of the job.
+        echo "${bindir}" >>"${GITHUB_PATH}"
+
+        echo "version=${version}" >>"${GITHUB_OUTPUT}"
+        echo "bin-path=${bindir}" >>"${GITHUB_OUTPUT}"
+        "${bindir}/datumctl" version || true
+
+    - name: Authenticate service account
+      shell: bash
+      env:
+        DATUM_SA_CREDENTIALS: ${{ inputs.credentials }}
+        DATUM_AUTH_HOSTNAME: ${{ inputs.auth-hostname }}
+      run: |
+        set -euo pipefail
+
+        : "${DATUM_SA_CREDENTIALS:?service account credentials are required}"
+        : "${DATUM_AUTH_HOSTNAME:?auth hostname is required}"
+
+        creds_file=$(mktemp)
+        trap 'rm -f "${creds_file}"' EXIT
+        chmod 600 "${creds_file}"
+
+        # Tolerate both raw-JSON and base64-encoded credentials. Decode only
+        # when the result is valid base64 *and* looks like JSON; otherwise treat
+        # the input as raw JSON.
+        if printf '%s' "${DATUM_SA_CREDENTIALS}" | base64 -d >"${creds_file}" 2>/dev/null \
+          && head -c1 "${creds_file}" | grep -q '{'; then
+          :
+        else
+          printf '%s' "${DATUM_SA_CREDENTIALS}" >"${creds_file}"
+        fi
+
+        datumctl login --credentials "${creds_file}" --hostname "${DATUM_AUTH_HOSTNAME}"
+        datumctl auth list


### PR DESCRIPTION
## What

Adds a **composite action** `setup-datumctl` that installs `datumctl` and authenticates a Datum service account, packaged like [`google-github-actions/setup-gcloud`](https://github.com/google-github-actions/setup-gcloud). Lifts the logic out of the infra repo's raw `provisioning/setup-datumctl` script (datum-cloud/infra#2728) into a versioned, externally-consumable action.

```yaml
- uses: datum-cloud/actions/setup-datumctl@v1
  with:
    credentials: ${{ secrets.DATUM_SA_CREDENTIALS }}
```

## Behavior

- **Install**: downloads the released tarball for the runner's OS/arch (Linux/macOS, x86_64/arm64), verifies the published SHA-256 checksum, installs to a job-scoped dir on `PATH` — no `sudo`.
- **Authenticate**: writes credentials to a temp file (mode 600, removed after login), tolerating both raw-JSON and base64-encoded values (matches the fix in datum-cloud/infra#2728), then `datumctl login`. Session lives in the datumctl keyring for later `datumctl`/`kubectl` steps.
- **Inputs**: `version` (default `v0.15.0`), `auth-hostname` (default `auth.datum.net`), `credentials` (required).
- **Outputs**: `version`, `bin-path`.

## Design note

The issue suggested a dedicated repo (`datum-cloud/setup-datumctl-action`). I placed it here instead, at the repo root path so it's consumable as `datum-cloud/actions/setup-datumctl@v1` alongside the other org actions and reusing this repo's release tags. Happy to extract to its own repo if independent versioning is preferred.

## Follow-up

- Migrate the infra E2E workflow off `provisioning/setup-datumctl` to this action (tracked in #79).

## Test plan

- [x] `action.yaml` validates as YAML
- [x] datumctl `v0.15.0` tarball asset names + checksum file confirmed against the release
- [ ] Exercise in a consumer workflow run

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)