### PR TITLE
docs: point agent guidance at shared PR conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,3 +200,6 @@ RUN go build -ldflags="-X k8s.io/component-base/version.gitVersion=${VERSION} \
 - `.github/workflows/` - Reusable GitHub Actions workflow definitions
 - `docs/` - Documentation for each action with usage examples and best practices
 - `renovate.json` - Renovate configuration for dependency updates
+## GitHub PR / Issue / Comment Conventions
+
+Follow the `datum-platform:pr-conventions` skill for all PRs, issues, and comments — including its concision rules: say it once (don't restate the summary as test-plan checkboxes, or describe the same behaviour in prose and again in a checklist), and cut every word carrying no fact. Compress, never omit — brevity must not drop facts.


### PR DESCRIPTION
## Summary

Agent guidance in this repo says nothing about how PRs and issues should read, so bodies restate the summary as test-plan checkboxes and re-sell the same point across paragraphs.

Adds a pointer to the shared `datum-platform:pr-conventions` skill, which now carries the concision rules. Pointer rather than a copied block, so the rule stays owned in one place.

## Test plan

- [x] Docs-only; no code or workflows touched

Related to https://github.com/datum-cloud/infra/issues/3714
